### PR TITLE
Fix download button and update reflection

### DIFF
--- a/reflection.html
+++ b/reflection.html
@@ -29,13 +29,10 @@
     <div class="card">
       <h2>My Reflection</h2>
       <div class="summary">Thoughts on the creative journey.</div>
-      <ul>
-        <li>What inspired these stories?</li>
-        <li>What challenges did I face?</li>
-        <li>What are my strengths and weaknesses?</li>
-        <li>What do I hope readers take away?</li>
-        <li>How will I grow from this?</li>
-      </ul>
+      <p>The inspiration for these stories came from real societies where freedom of speech and political choice are limited in subtle but powerful ways. I wanted to explore how quiet pressures shape daily life.</p>
+      <p>A significant challenge was publishing the website through git. Setting up the repository and managing deployment steps were unfamiliar, and I ran into several technical issues. OpenAI’s Codex provided useful guidance and helped me troubleshoot when I got stuck.</p>
+      <p>My strength lies in creating atmosphere and hinting at the larger social context through small details. I do, however, sometimes hold back too much, which can make my writing less direct than I intend.</p>
+      <p>I hope readers will notice how easily freedom can be narrowed by routine or policy, and think about the importance of open discussion. This project has shown me where I need to improve my technical skills, and I am motivated to learn more about web publishing and clearer storytelling.</p>
       <div class="video-container">
         <iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" allowfullscreen></iframe>
       </div>

--- a/story1.html
+++ b/story1.html
@@ -26,15 +26,15 @@
 
   <div class="main">
     <div class="breadcrumb">📍 Story #1</div>
-    <div class="card">
+    <div class="card" id="story1">
       <h2>The Form</h2>
       <div class="summary">Navigating bureaucracy for a simple request.</div>
-      <div class="metadata">📅 12/06/2025 · 🖋 Written · ~500 words</div>
+      <div class="metadata">📅 12/06/2025 · 🖋 Written · ~160 words</div>
       <p>Amira stood in line at the Public Affairs Office, clutching Form 72C. Around her, people murmured softly, eyes fixed on the floor tiles. The walls were covered in posters: ‘Civic Unity Ensures Stability.’ She had filled out every section, double-checked each tick box, and memorised her identification number.</p>
       <p>At the window, the clerk took the form and examined it for a long moment. Amira kept her expression neutral, recalling her neighbour’s warning: ‘If you look nervous, they ask questions.’</p>
       <p>The clerk stamped the paper without a word and slid it back. Amira exhaled quietly. She would be allowed to attend her cousin’s wedding, provided she filed a Travel Permission Request before midday next Monday. It was, she thought, a small price for freedom—until she remembered the neighbour who hadn’t received approval last spring and moved away without saying goodbye.</p>
       <p>As she stepped outside, Amira glanced up at the discreet security camera on the lamppost. She smiled, just in case.</p>
-      <a class="download-button" href="data:text/plain;charset=utf-8,[Story Title One]%0AWritten by [Your Name].%0A%0A[Your story text goes here.]%0A%0AAll rights reserved. This story or any portion thereof may not be reproduced or used in any manner whatsoever without the express written permission of the author." download="Story1_[YourName].txt">📁 Download Story</a>
+      <a class="download-button" href="#" onclick="downloadStory('story1', 'Story1.txt', 'The Form'); return false;">📁 Download Story</a>
     </div>
   </div>
 
@@ -51,6 +51,20 @@
 
   function toggleSidebar() {
     document.body.classList.toggle('sidebar-open');
+  }
+
+  function downloadStory(containerId, filename, title) {
+    const container = document.getElementById(containerId);
+    const paragraphs = container.querySelectorAll('p');
+    const text = Array.from(paragraphs).map(p => p.textContent).join('\n\n');
+    const rights = 'All rights reserved. This story or any portion thereof may not be reproduced or used in any manner whatsoever without the express written permission of the author.';
+    const content = title + '\n\n' + text + '\n\n' + rights;
+    const blob = new Blob([content], {type: 'text/plain'});
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = filename;
+    link.click();
+    URL.revokeObjectURL(link.href);
   }
 
   document.querySelectorAll('.sidebar .nav-link').forEach(link => {

--- a/story2.html
+++ b/story2.html
@@ -26,16 +26,16 @@
 
   <div class="main">
     <div class="breadcrumb">📍 Story #2</div>
-    <div class="card">
+    <div class="card" id="story2">
       <h2>The Committee</h2>
       <div class="summary">Where suggestions are welcomed and ignored.</div>
-      <div class="metadata">📅 12/06/2025 · 🖋 Written · ~480 words</div>
+      <div class="metadata">📅 12/06/2025 · 🖋 Written · ~180 words</div>
       <p>Elias attended the monthly Residents’ Meeting as required. The agenda, projected on the wall, listed items in clear, bureaucratic language: ‘Public Space Maintenance’, ‘Community Feedback’, ‘Civic Responsibility Reminders’.</p>
       <p>Each time someone raised a suggestion, the Committee Chair smiled and noted it down. ‘We appreciate your input,’ she said, though no changes ever followed. The minutes were distributed, carefully edited, always positive.</p>
       <p>Elias once mentioned that the benches in the park were missing slats. The next morning, an official letter arrived at his door: ‘Thank you for your concern. Please refrain from direct maintenance requests. All issues must be submitted through proper channels.’</p>
       <p>Now he attended, nodded at the right moments, and said nothing. He watched others do the same, the room thick with polite agreement. Outside, the city carried on—a place where rules were followed, and those who asked too many questions found themselves gently advised to rest, or to seek relocation to a quieter district.</p>
       <p>Each meeting ended the same way: with applause, and a reminder to ‘keep communication open, for the stability of all’.</p>
-      <a class="download-button" href="data:text/plain;charset=utf-8,[Story Title Two]%0AWritten by [Your Name].%0A%0A[Your story text goes here.]%0A%0AAll rights reserved. This story or any portion thereof may not be reproduced or used in any manner whatsoever without the express written permission of the author." download="Story2_[YourName].txt">📁 Download Story</a>
+      <a class="download-button" href="#" onclick="downloadStory('story2', 'Story2.txt', 'The Committee'); return false;">📁 Download Story</a>
     </div>
   </div>
 
@@ -52,6 +52,20 @@
 
   function toggleSidebar() {
     document.body.classList.toggle('sidebar-open');
+  }
+
+  function downloadStory(containerId, filename, title) {
+    const container = document.getElementById(containerId);
+    const paragraphs = container.querySelectorAll('p');
+    const text = Array.from(paragraphs).map(p => p.textContent).join('\n\n');
+    const rights = 'All rights reserved. This story or any portion thereof may not be reproduced or used in any manner whatsoever without the express written permission of the author.';
+    const content = title + '\n\n' + text + '\n\n' + rights;
+    const blob = new Blob([content], {type: 'text/plain'});
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = filename;
+    link.click();
+    URL.revokeObjectURL(link.href);
   }
 
   document.querySelectorAll('.sidebar .nav-link').forEach(link => {


### PR DESCRIPTION
## Summary
- make download button generate text files
- append rights reserved message to downloaded files
- fix inaccurate word counts on each story page
- replace reflection page bullet list with detailed reflection text

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685106dab014832dbd53e5165eede113