### PR TITLE
Fix mobile navbar visibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -262,14 +262,15 @@ header {
 
   .sidebar {
     position: fixed;
-    left: -240px;
+    left: 0;
     top: 0;
     height: 100%;
-    transition: left 0.3s;
+    transform: translateX(-100%);
+    transition: transform 0.3s;
     z-index: 999;
   }
   body.sidebar-open .sidebar {
-    left: 0;
+    transform: translateX(0);
   }
 
   .main {


### PR DESCRIPTION
## Summary
- ensure mobile sidebar is hidden by default and slides in when hamburger is tapped

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68511ca02594832dbba8aa34247afc0d